### PR TITLE
feat: Add automated local D1 database setup script for new contributors

### DIFF
--- a/setup-local.sh
+++ b/setup-local.sh
@@ -41,7 +41,7 @@ fi
 # Apply schema locally
 echo ""
 echo "📋 Step 4: Applying database schema locally..."
-wrangler d1 execute pr-tracker --local --file=./schema.sql
+wrangler d1 execute DB --local --file=./schema.sql  # <-- Changed this line
 echo "✅ Schema applied successfully"
 
 # Setup .env file


### PR DESCRIPTION
## Description
This PR introduces an automated setup script (`setup-local.sh`) to simplify local development for new contributors. The script handles:
- **D1 database creation** (or fetches existing database ID).
- **Automatic `wrangler.toml` updates** with the correct `database_id`.
- **Schema application** to the local database.
- **Environment file setup** (`.env` from `env.example`).

## Problem Solved
Previously, new contributors faced manual setup hurdles:
- ❌ Confusion over `database_id` placeholders in `wrangler.toml`.
- ❌ Manual steps to create D1 databases and apply schemas.
- ❌ No clear guidance for local development.

Just run
chmod+x ./setup-local.sh
./setup-local.sh

Some Testing
<img width="922" height="983" alt="image" src="https://github.com/user-attachments/assets/62bf5879-ec73-442b-9174-ab66409d9c55" />

<img width="1916" height="775" alt="image" src="https://github.com/user-attachments/assets/35b30a16-a473-4102-9841-b91bbd4cb3da" />

