### PR TITLE
Fix: Standardize database name to pr_tracker across config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ wrangler login
 
 4. Create the D1 database:
 ```bash
-wrangler d1 create pr-tracker
+wrangler d1 create pr_tracker
 ```
 
 5. Update `wrangler.toml` with your database ID from the previous step.
 
 6. Initialize the database schema:
 ```bash
-wrangler d1 execute pr-tracker --file=./schema.sql
+wrangler d1 execute pr_tracker --file=./schema.sql
 ```
 
 ### Development


### PR DESCRIPTION
### Description

Fixes: #24 

This PR resolves a database name inconsistency between `README.md` and `wrangler.toml`.

Previously:

* `README.md` instructed users to create a database named `pr-tracker`
* `wrangler.toml` referenced `pr_tracker`

This mismatch caused connection failures during initial setup because the configured binding did not match the actual database name.

### Changes

* Standardized database name to `pr_tracker`
* Updated:
  * `README.md`
