### PR TITLE
Add GitHub icon linking to repository Pull Requests in sidebar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -477,8 +477,31 @@
                 setRepoItemActiveState(li, currentRepo === li.dataset.repo);
 
                 li.innerHTML = `
-                    <div class="repo-name text-sm font-semibold text-slate-800 dark:text-slate-200">${repo.repo_owner}/${repo.repo_name}</div>
-                    <div class="repo-count mt-0.5 text-xs text-slate-500 dark:text-slate-400">${repo.pr_count} PR${repo.pr_count === 1 ? '' : 's'}</div>
+                    <div class="flex items-center justify-between">
+                        
+                        <div>
+                            <div class="repo-name text-sm font-semibold text-slate-800 dark:text-slate-200">
+                                ${repo.repo_owner}/${repo.repo_name}
+                            </div>
+
+                            <div class="repo-count mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+                                ${repo.pr_count} PR${repo.pr_count === 1 ? '' : 's'}
+                            </div>
+                        </div>
+
+                        <a href="https://github.com/${repo.repo_owner}/${repo.repo_name}/pulls"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-slate-500 hover:text-[#BC0000] dark:hover:text-red-400 ml-2 github-pr-link"
+                        title="View Pull Requests on GitHub"
+                        onclick="event.stopPropagation();">
+
+                            <i class="fab fa-github text-lg text-red-600 hover:text-red-700 transition-colors"></i>
+
+
+                        </a>
+
+                    </div>
                 `;
 
                 li.addEventListener('click', () => {


### PR DESCRIPTION
Fixes #100 

Adds a GitHub icon next to each repository in the sidebar. Clicking the icon opens the repository’s Pull Requests page in a new tab.

Screenshots:-
<img width="1919" height="902" alt="Screenshot 2026-02-16 122811" src="https://github.com/user-attachments/assets/21f80c19-5217-418c-b1c9-84a524e748c3" />
<img width="1919" height="917" alt="Screenshot 2026-02-16 122825" src="https://github.com/user-attachments/assets/17ba79ac-715d-4be2-9bd0-78c7ffb8b5b9" />
