### PR TITLE
sorting fixed

### DIFF
--- a/src/handlers.py
+++ b/src/handlers.py
@@ -282,7 +282,7 @@ async def handle_list_prs(env, repo_filter=None, page=1, per_page=30, sort_by=No
                     
                     # Add NULL handling and column sort
                     # NULL values should appear last regardless of sort direction
-                    sort_clauses.append(f'{sql_expr} IS NOT NULL, {sql_expr} {direction}')
+                    sort_clauses.append(f'{sql_expr} IS NOT NULL DESC, {sql_expr} {direction}')
                 else:
                     # Log invalid column attempts for security monitoring
                     print(f"Security: Rejected invalid sort column: {col}")

--- a/test-sorting-security.js
+++ b/test-sorting-security.js
@@ -104,10 +104,10 @@ function testSortingSecurity() {
     // Test 8: Verify NULL handling in sort
     testResult(
       'NULL values handling in sort',
-      /IS NOT NULL/.test(handlersContent),
-      'NULL values are handled (appear last in results)'
+      /IS NOT NULL DESC/.test(handlersContent),
+      'NULL values are handled correctly (IS NOT NULL DESC ensures they appear last)'
     );
-    
+
     // Test 9: Verify direction validation (ASC/DESC only)
     testResult(
       'Sort direction validation',


### PR DESCRIPTION
The backend was generating SQL sort clauses like this: `ORDER BY` column `IS NOT NULL, column DESC`
In SQLite, `IS NOT NULL` evaluates to 1 (true) or 0 (false). Without an explicit `DESC`, the sorted order for the first part of the clause would be 0 (NULLs) then 1 (NOT NULLs). This caused PRs without scores to always appear at the top.
I updated the backend logic in handlers.py to use `IS NOT NULL DESC`: `ORDER BY column IS NOT NULL DESC, column DESC`
This ensures that `NOT NULL` values (1) always come before NULL values (0), placing analyzed PRs at the top and unanalyzed PRs at the bottom, regardless of the second part of the order clause.
Closes: #189 
Closes: #169 