### PR TITLE
fix(handlers): validate PR ID extracted from path in timeline, review-analysis and readiness endpoints

### DIFF
--- a/src/handlers.py
+++ b/src/handlers.py
@@ -1241,7 +1241,11 @@ async def handle_pr_timeline(request, env, path):
     """
     try:
         # Extract PR ID from path: /api/prs/123/timeline
-        pr_id = path.split('/')[3]  # Split by / and get the ID
+        path_parts = path.split('/')
+        if len(path_parts) < 4 or not path_parts[3].isdigit():
+            return Response.new(json.dumps({'error': 'Invalid PR ID in path'}),
+                              {'status': 400, 'headers': {'Content-Type': 'application/json'}})
+        pr_id = path_parts[3]
         
         # Get client IP for rate limiting
         client_ip = (
@@ -1331,7 +1335,11 @@ async def handle_pr_review_analysis(request, env, path):
     """
     try:
         # Extract PR ID from path: /api/prs/123/review-analysis
-        pr_id = path.split('/')[3]
+        path_parts = path.split('/')
+        if len(path_parts) < 4 or not path_parts[3].isdigit():
+            return Response.new(json.dumps({'error': 'Invalid PR ID in path'}),
+                              {'status': 400, 'headers': {'Content-Type': 'application/json'}})
+        pr_id = path_parts[3]
         
         # Get client IP for rate limiting
         client_ip = (
@@ -1537,7 +1545,11 @@ async def handle_pr_readiness(request, env, path):
     """
     try:
         # Extract PR ID from path: /api/prs/123/readiness
-        pr_id = path.split('/')[3]
+        path_parts = path.split('/')
+        if len(path_parts) < 4 or not path_parts[3].isdigit():
+            return Response.new(json.dumps({'error': 'Invalid PR ID in path'}),
+                              {'status': 400, 'headers': {'Content-Type': 'application/json'}})
+        pr_id = path_parts[3]
         
         # Check cache first
         cached_result = await get_readiness_cache(env, pr_id)


### PR DESCRIPTION
## Summary
Added validation for PR ID extraction from URL path in three endpoints.

## Problem
All three sub-resource endpoints extracted the PR ID using a fragile index-based split:
```python
pr_id = path.split('/')[3]  # /api/prs/123/timeline
```

This would raise an unhandled `IndexError` if the path had fewer than 4 segments, or silently pass a non-numeric string to database queries if the path was malformed (e.g. `/api/prs/abc/timeline`).

## Fix
Added explicit validation before using the extracted ID in all three handlers:
```python
path_parts = path.split('/')
if len(path_parts) < 4 or not path_parts[3].isdigit():
    return Response.new(
        json.dumps({'error': 'Invalid PR ID in path'}),
        {'status': 400, 'headers': {'Content-Type': 'application/json'}}
    )
pr_id = path_parts[3]
```

## Affected Endpoints
- `GET /api/prs/{id}/timeline` — `handle_pr_timeline`
- `GET /api/prs/{id}/review-analysis` — `handle_pr_review_analysis`
- `GET /api/prs/{id}/readiness` — `handle_pr_readiness`

## Files Changed
- `src/handlers.py` — 3 locations, 15 insertions, 3 deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented robust validation for pull request identifiers across multiple operations to catch invalid submissions and prevent downstream processing failures.
  * Invalid pull request IDs now return immediate, clear error responses instead of proceeding silently through the system, improving error clarity and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->